### PR TITLE
Remove timecop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
-  gem 'timecop'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    timecop (0.9.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     websocket-driver (0.6.5)
@@ -190,7 +189,6 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers
   simplecov
-  timecop
   tzinfo-data
 
 BUNDLED WITH

--- a/spec/commands/authenticate_user_command_spec.rb
+++ b/spec/commands/authenticate_user_command_spec.rb
@@ -3,11 +3,13 @@
 require 'rails_helper'
 
 describe AuthenticateUserCommand do
+  include ActiveSupport::Testing::TimeHelpers
+
   let!(:user) { create(:user, id: 1) }
 
   context 'with right user and password' do
-    before { Timecop.freeze(2017, 1, 1, 0, 0, 1, 1) }
-    after { Timecop.return }
+    before { travel_to Time.zone.local(2017, 1, 1, 0, 0, 1, 1) }
+    after { travel_back }
 
     let(:expected_token) do
       'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjE0ODMzMTUyMDF9.' \

--- a/spec/commands/decode_authentication_command_spec.rb
+++ b/spec/commands/decode_authentication_command_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe DecodeAuthenticationCommand do
+  include ActiveSupport::Testing::TimeHelpers
+
   context 'without token' do
     subject { described_class.call('') }
 
@@ -26,8 +28,8 @@ describe DecodeAuthenticationCommand do
   end
 
   context 'with invalid token' do
-    before { Timecop.freeze(2017, 1, 1) }
-    after { Timecop.return }
+    before { travel_to Time.zone.local(2017, 1, 1) }
+    after { travel_back }
 
     let(:expired_header) do
       {
@@ -44,8 +46,8 @@ describe DecodeAuthenticationCommand do
   end
 
   context 'with valid token' do
-    before { Timecop.freeze(2017, 1, 1) }
-    after { Timecop.return }
+    before { travel_to Time.zone.local(2017, 1, 1) }
+    after { travel_back }
     let!(:user) { create(:user, id: 1) }
 
     let(:expired_header) do


### PR DESCRIPTION
For this simple use case, use ActiveSupport's time helpers for time travel

See http://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html